### PR TITLE
Add ::backdrop and ::selection as custom variable selectors.

### DIFF
--- a/mvp.css
+++ b/mvp.css
@@ -1,6 +1,6 @@
 /* MVP.css v1.14 - https://github.com/andybrewer/mvp */
 
-:root {
+:root, ::backdrop, ::selection {
     --active-brightness: 0.85;
     --border-radius: 5px;
     --box-shadow: 2px 2px 10px;


### PR DESCRIPTION
As described in [_":root isn't global"_](https://dev.to/kilianvalkhof/root-isnt-global-2km8), the custom properties (CSS Variables) set in `:root` don't reach `::backdrop` and `::selection`.

In order to use custom properties for styling there as well, the selector where the properties are declared needs to specificly reference `::backdrop` and `::selection`.

This MR adds those references.